### PR TITLE
Add lint workflow and badge to README

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on: # yamllint disable-line rule:truthy
+  push: null
+  pull_request: null
+
+permissions: {}
+
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
+
+      - name: Super-linter
+        uses: super-linter/super-linter@v7.4.0 # x-release-please-version
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <img src="https://img.shields.io/github/license/pellux-network/edx52display" alt="GitHub License" />
   <img src="https://img.shields.io/github/go-mod/go-version/pellux-network/edx52display?logo=go&logoSize=auto&label=%20&color=grey"
   alt="GitHub go.mod Go version" />
+  <img src="https://github.com/pellux-network/edx52display/actions/workflows/super-linter.yml/badge.svg" alt="Super-Linter Status" />
   <img src="https://img.shields.io/github/actions/workflow/status/pellux-network/edx52display/go.yml" alt="GitHub Actions Workflow Status" />
   <img src="https://img.shields.io/github/issues/pellux-network/edx52display" alt="GitHub Issues" />
   <img src="https://img.shields.io/github/issues-pr/pellux-network/edx52display" alt="GitHub Pull Requests" />


### PR DESCRIPTION
Introduces a GitHub Actions workflow for linting using super-linter and adds a corresponding status badge to the README.